### PR TITLE
Fix bootloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 Upgrading KOOMPI OS to the latest release is no longer required to install from the ISO. This project aims to making upgrading OS easily by just running one command. Copy and paste the command below into your terminal and done.
 
 ```bash
-curl -Ssf https://raw.githubusercontent.com/koompi/os-upgrade/master/installer.sh -O && chmod +x installer.sh && bash installer.sh
+curl -Ssf https://raw.githubusercontent.com/koompi/os-upgrade/master/installer.sh -O && bash installer.sh
 ```

--- a/installer.sh
+++ b/installer.sh
@@ -306,20 +306,11 @@ function remove_dropped_packages() {
         pulseaudio-bluetooth;
 }
 
-function clean_efi() {
-    boot=($(lsblk --list --fs | grep FAT32))
-    boot_drive=/dev/${boot[0]}
-
-    as_su umount $boot_drive >/dev/null 2>&1
-    as_su mkfs.fat -F32 $boot_drive >/dev/null 2>&1
-    as_su systemctl daemon-reload >/dev/null 2>&1
-    as_su mount $boot_drive /boot/efi >/dev/null 2>&1
-    as_su grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=KOOMPI_OS >/dev/null 2>&1
-    as_su bash -c 'genfstab -U -p / > /etc/fstab' >/dev/null 2>&1
-}
-
 function update_grub() {
-    [ -d /sys/firmware/efi ] && clean_efi
+    as_su rm -rf /boot/efi/* /boot/grub/*
+    smart_install grub;
+    as_su mkinitcpio -P >/dev/null 2>&1
+    as_su grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=KOOMPI_OS >/dev/null 2>&1
     as_su grub-mkconfig -o /boot/grub/grub.cfg >/dev/null 2>&1
 }
 


### PR DESCRIPTION
I found out that reformat efi directory isn't really necessary. The key to fix the bootloader is 
- Clean install of grub pacman
- Regenerate Initramfs (either by mkinicpio or reinstall kernel)
- reconfigure grub

Therefore, I remove the clean efi function, and did the above in the update bootloader function. 

Worked on a Fresh install of KOOMPI OS 2.7.0 and no longer mess with the Genfstab sudo fail substitution,